### PR TITLE
Add Dockerfile for building Docker image based on Node.js LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# See https://github.com/nodesource/docker-node
+FROM    nodesource/jessie:LTS
+
+# cache package.json and node_modules to speed up builds
+ADD     package.json package.json
+RUN     npm install
+
+# Expose the default jenkins-coverage-badge port
+EXPOSE  9913
+
+# Add your source files
+ADD     . .
+CMD     ["npm","start"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ Now you can get coverage badge with,
 ```
 ![coverage](http://d7.mnpk.org/jcb/jenkins/c/http/d7.mnpk.org/jenkins/job/goyo?style=flat-square)
 ```
+
+## Docker service
+
+Build the Docker image:
+
+    docker build -t nodejs-jenkins-coverage-badge .
+
+Run the Docker container in detached/daemon mode:
+
+    docker run -p 9913:9913 -d nodejs-jenkins-coverage-badge
  
 ## License
 MIT


### PR DESCRIPTION
This PR adds a Dockerfile for running jenkins-coverage-badge with Node.js LTS
