### PR TITLE
Prevent badge icon caching by GitHub’s CDN

### DIFF
--- a/server.js
+++ b/server.js
@@ -30,6 +30,7 @@ app.get('/jenkins/c/http/*', function(req,res) {
           }
           console.log('[GET] ' + '/jenkins/c/http/' + jurl)
           console.log('      generating badge(' + badge_url + ')')
+          res.setHeader('Cache-Control', 'no-cache');
           res.redirect(badge_url)
         }
       }

--- a/server.js
+++ b/server.js
@@ -30,6 +30,7 @@ app.get('/jenkins/c/http/*', function(req,res) {
           }
           console.log('[GET] ' + '/jenkins/c/http/' + jurl)
           console.log('      generating badge(' + badge_url + ')')
+          res.setHeader('Expires', 'Tue, 15 Apr 1980 12:00:00 GMT');
           res.setHeader('Cache-Control', 'no-cache');
           res.redirect(badge_url)
         }


### PR DESCRIPTION
This PR includes additional HTTP headers in the response to prevent caching by GitHub’s CDN.
